### PR TITLE
Fix initialization of the ff buffer

### DIFF
--- a/denops/@ddu-uis/ff.ts
+++ b/denops/@ddu-uis/ff.ts
@@ -573,6 +573,7 @@ export class Ui extends BaseUi<Params> {
       await fn.setwinvar(denops, winid, "&wrap", 0);
       await fn.setwinvar(denops, winid, "&signcolumn", "no");
 
+      await fn.setbufvar(denops, bufnr, "&bufhidden", "unload");
       await fn.setbufvar(denops, bufnr, "&buftype", "nofile");
       await fn.setbufvar(denops, bufnr, "&filetype", "ddu-ff");
       await fn.setbufvar(denops, bufnr, "&swapfile", 0);

--- a/denops/@ddu-uis/ff.ts
+++ b/denops/@ddu-uis/ff.ts
@@ -174,7 +174,7 @@ export class Ui extends BaseUi<Params> {
     }
 
     // Note: buffers may be restored
-    if (!this.buffers[args.options.name]) {
+    if (!this.buffers[args.options.name] || winid < 0) {
       await this.initOptions(args.denops, args.options, bufnr);
     }
 


### PR DESCRIPTION
## Problem
Buffer initialization is incomplete when the FF buffer is reopened.
Also, the behavior changes depending on the global option `&hidden`.

1. Do `:set nohidden`.
2. Open the FF buffer. (`FileType` event is fired.)
3. Close the FF buffer. (The buffer becomes unload and syntax etc. are lost.)
4. Re-open the FF buffer. (`FileType` event is **NOT** fired.)

## Solution
Initialize the buffer options if `winid < 0` (it is not assigned to window).
Always unload the ff buffer on quit.