### PR TITLE
Fix can't open floating filter window when floatingBorder is List

### DIFF
--- a/autoload/ddu/ui/ff/filter.vim
+++ b/autoload/ddu/ui/ff/filter.vim
@@ -57,7 +57,7 @@ function! ddu#ui#ff#filter#_floating(bufnr, parent, params) abort
 
   let row = a:params.filterFloatingPosition ==# 'bottom'
         \ ? winheight(a:parent) : -1
-  if a:params.floatingBorder !=# 'none'
+  if a:params.floatingBorder isnot# 'none'
     if a:params.filterFloatingPosition ==# 'top'
       let row -= 2
     endif


### PR DESCRIPTION
This PR is fix can't open filter window with `E691: Can only compare List with List"` when using under setting.

```vim
call ddu#custom#patch_global({
\   'ui': 'ff',
\   'uiParams': {
\     'ff': {
\       'split': 'floating',
\       'floatingBorder': ['.', '.', '.', ':', ':', '.', ':', ':'],
\     },
\   },
\ })
```