### PR TITLE
fix problems with filter window

### DIFF
--- a/denops/@ddu-uis/ff.ts
+++ b/denops/@ddu-uis/ff.ts
@@ -281,7 +281,7 @@ export class Ui extends BaseUi<Params> {
       [...this.selectedItems],
     );
 
-    if (winid < 0) {
+    if (this.filterBufnr < 0) {
       if (args.uiParams.startFilter) {
         this.filterBufnr = await args.denops.call(
           "ddu#ui#ff#filter#_open",
@@ -377,12 +377,8 @@ export class Ui extends BaseUi<Params> {
       await fn.getline(args.denops, "."),
     );
 
-    if (this.filterBufnr > 0) {
-      const filterWinNr = await fn.bufwinnr(args.denops, this.filterBufnr);
-      if (filterWinNr > 0) {
-        await args.denops.cmd(`close! ${filterWinNr}`);
-      }
-    }
+    await this.closeFilterWindow(args.denops);
+
     if (
       args.uiParams.split == "no" || (await fn.winnr(args.denops, "$")) == 1
     ) {
@@ -514,6 +510,15 @@ export class Ui extends BaseUi<Params> {
     }
   }
 
+  private async closeFilterWindow(denops: Denops): Promise<void> {
+    if (this.filterBufnr > 0) {
+      const filterWinNr = await fn.bufwinnr(denops, this.filterBufnr);
+      if (filterWinNr > 0) {
+        await denops.cmd(`close! ${filterWinNr}`);
+      }
+    }
+  }
+
   actions: UiActions<Params> = {
     chooseAction: async (args: {
       denops: Denops;
@@ -521,6 +526,8 @@ export class Ui extends BaseUi<Params> {
       uiParams: Params;
       actionParams: unknown;
     }) => {
+      await this.closeFilterWindow(args.denops);
+
       const items = await this.getItems(args.denops, args.uiParams);
       if (items.length == 0) {
         return ActionFlags.None;


### PR DESCRIPTION
- fix problem that may cause `E25` error.
- fix problem that filter windows does not open when execute `chooseAction`.

After executing `chooseAction` with filter window displayed, an error occurs when trying to open filter window. Also, if `startFilter` is `true`, I think the filter window should remain visible after the `chooseAction` is executed.

```vim
:call ddu#start({})
<ESC><C-w>p
:call ddu#ui#ff#do_action('chooseAction')
:call ddu#ui#ff#do_action('openFilterWindow')
```
<details>
<summary>minimal.vim</summary>

```vim
let plugins = [
       \ "/home/erw7/.config/nvim/dein/repos/github.com/Shougo/ddu-ui-ff",
       \ "/home/erw7/.config/nvim/dein/repos/github.com/vim-denops/denops.vim",
       \ "/home/erw7/.config/nvim/dein/repos/github.com/Shougo/ddu.vim",
       \ "/home/erw7/.config/nvim/dein/repos/github.com/Shougo/ddu-kind-file",
       \ "/home/erw7/.config/nvim/dein/repos/github.com/Shougo/ddu-source-file",
       \ "/home/erw7/.config/nvim/dein/repos/github.com/Shougo/ddu-source-action",
       \ "/home/erw7/.config/nvim/dein/repos/github.com/Shougo/ddu-filter-matcher_substring",
       \]

let &rtp = &rtp . ',' . join(plugins, ',')

filetype plugin indent on

call ddu#custom#patch_global({
      \  'ui' : 'ff',
      \  'uiParams' : {
      \    'ff' : {'split' : 'floating', 'startFilter' : v:true,},
      \  },
      \  'sources' : [{'name' : 'file',}],
      \  'sourceOptions' : {'_' : {'matchers' : ['matcher_substring',]}},
      \  'kindOptions' : {
      \    'file' : {'defaultAction' : 'open',},
      \    'action' : {'defaultAction' : 'do',},
      \  },
      \})
```
</details>

<details>
<summary>error message</summary>

```
Error detected while processing function ddu#ui#ff#do_action[13]..ddu#ui_action[1]..ddu#_request[22]..denops#request[1]..denops#server#request[6]..<SNR>30_request:
line    1:
Error invoking 'invoke' on channel 4:
Error: Failed to call 'uiAction' with ["default","openFilterWindow",{}]: Error: Failed to call 'call' with ["ddu#ui#ff#filter#_open","default","",-1,{"autoAction":{},"autoResize":false,"cursorPos":-1,"displaySourceName":"no","filterFloatingPosition":"bottom","filterSplitDirection":"botright","filterUpdateTime":0,"floatingBorder":"none","highlights":{},"ignoreEmpty":false,"previewCol":0,"previewFloating":false,"previewHeight":10,"previewRow":0,"previewVertical":false,"previewWidth":40,"previewFloatingBorder":"none","prompt":"","reversed":false,"split":"floating","splitDirection":"botright","startFilter":true,"statusline":true,"winCol":40,"winHeight":20,"winRow":11,"winWidth":80}]: Error: Failed to call 'nvim_call_function' with ["ddu#ui#ff#filter#_open",["default","",-1,{"autoAction":{},"autoResize":false,"cursorPos":-1,"displaySourceName":"no","filterFloatingPosition":"bottom","filterSplitDirection":"botright","filterUpdateTime":0,"floatingBorder":"none","highlights":{},"ignoreEmpty":false,"previewCol":0,"previewFloating":false,"previewHeight":10,"previewRow":0,"previewVertical":false,"previewWidth":40,"previewFloatingBorder":"none","prompt":"","reversed":false,"split":"floating","splitDirection":"botright","startFilter":true,"statusline":true,"winCol":40,"winHeight":20,"winRow":11,"winWidth":80}]]: [0,"Vim(call):E21: Cannot make changes, 'modifiable' is off"]
    at Session.call (https://deno.land/x/msgpack_rpc@v3.1.6/session.ts:207:13)
    at async Service.call (file:///home/erw7/.config/nvim/dein/repos/github.com/vim-denops/denops.vim/denops/@denops-private/service.ts:92:12)
    at async Session.call (file:///home/erw7/.config/nvim/dein/repos/github.com/vim-denops/denops.vim/denops/@denops-private/service.ts:141:14)
    at async Session.dispatch (https://deno.land/x/msgpack_rpc@v3.1.6/session.ts:99:12)
    at async https://deno.land/x/msgpack_rpc@v3.1.6/session.ts:108:18
    at async Session.handleRequest (https://deno.land/x/msgpack_rpc@v3.1.6/session.ts:104:29)
    at Session.call (https://deno.land/x/msgpack_rpc@v3.1.6/session.ts:207:13)
    at async DenopsImpl.call (file:///home/erw7/.config/nvim/dein/repos/github.com/vim-denops/denops.vim/denops/@denops/impl.ts:28:12)
    at async openFilterWindow (file:///home/erw7/.config/nvim/dein/repos/github.com/Shougo/ddu-ui-ff/denops/@ddu-uis/ff.ts:586:26)
    at async Ddu.uiAction (file:///home/erw7/.config/nvim/dein/repos/github.com/Shougo/ddu.vim/denops/ddu/ddu.ts:394:19)
    at async Session.uiAction (file:///home/erw7/.config/nvim/dein/repos/github.com/Shougo/ddu.vim/denops/ddu/app.ts:206:7)
    at async Session.dispatch (https://deno.land/x/msgpack_rpc@v3.1.6/session.ts:99:12)
    at async https://deno.land/x/msgpack_rpc@v3.1.6/session.ts:108:18
    at async Session.handleRequest (https://deno.land/x/msgpack_rpc@v3.1.6/session.ts:104:29)
    at Session.call (https://deno.land/x/msgpack_rpc@v3.1.6/session.ts:207:13)
    at async Service.dispatch (file:///home/erw7/.config/nvim/dein/repos/github.com/vim-denops/denops.vim/denops/@denops-private/service.ts:107:14)
    at async Session.invoke (file:///home/erw7/.config/nvim/dein/repos/github.com/vim-denops/denops.vim/denops/@denops-private/host/nvim.ts:48:16)
    at async Session.dispatch (https://deno.land/x/msgpack_rpc@v3.1.6/session.ts:99:12)
    at async https://deno.land/x/msgpack_rpc@v3.1.6/session.ts:108:18
    at async Session.handleRequest (https://deno.land/x/msgpack_rpc@v3.1.6/session.ts:104:29)
```
<details>