### PR TITLE
don't allow backspacing over line breaks in filter

### DIFF
--- a/autoload/ddu/ui/ff/filter.vim
+++ b/autoload/ddu/ui/ff/filter.vim
@@ -24,6 +24,11 @@ function! ddu#ui#ff#filter#_open(name, input, bufnr, params) abort
           \ <buffer> call s:check_update()
   augroup END
 
+  if index(split(&backspace, ','), 'eol') >= 0
+    set backspace-=eol
+    autocmd BufLeave <buffer> ++once set backspace+=eol
+  endif
+
   " Note: prompt must set after cursor move
   if a:params.prompt !=# ''
     setlocal signcolumn=yes


### PR DESCRIPTION
filterでのバックスペースの挙動を制限することを提案します。

現在、`backspace`に`eol`をセットしている場合バックスペースによって改行が削除され、前回filterに入力した内容が表示されます。  
これはバッファとしては当たり前のことですが、「フィルター」としては違和感のある挙動だと感じました。

私はfilterを利用している時、それが通常のバッファであると認識はせず、特殊な「検索窓」のようなものに入力をしていると認識します。  
そのため、バックスペースによって改行が削除されたとき、前回の入力内容が唐突に出てきたように感じます。

この提案は各自で対応可能なものですが、ファジーファインダーとしてプラグイン側で対応した方がわかりやすいのではないか、と思いました。

よろしくお願いします。

(行頭行末での左右矢印キーで前後の行に移動するのも制限した方が良いと思うのですが、方法がわからない、かつ、問題となる頻度が小さいと感じたので含めていません)