### PR TITLE
Make specifiable border when `previewVertical = v:true` too

### DIFF
--- a/autoload/ddu/ui/ff.vim
+++ b/autoload/ddu/ui/ff.vim
@@ -184,6 +184,7 @@ function! ddu#ui#ff#_open_preview_window(params, bufnr) abort
            \ 'col': win_col,
            \ 'width': preview_width,
            \ 'height': preview_height,
+           \ 'border': a:params.previewFloatingBorder,
            \ })
     else
       execute 'vert resize ' . preview_width


### PR DESCRIPTION
In the current implementation, `previeeFloatingBorder` is applied only when `previewVertical` is `v:false`.
But I think the border should be specifiable when `previewVertial` is `v:true` too.