### PR TITLE
Fix cursorPos default value

### DIFF
--- a/denops/@ddu-uis/ff.ts
+++ b/denops/@ddu-uis/ff.ts
@@ -438,7 +438,7 @@ export class Ui extends BaseUi<Params> {
   private async getItem(
     denops: Denops,
     uiParams: Params,
-  ): null | Promise<DduItem> {
+  ): Promise<DduItem | null> {
     const idx = await this.getIndex(denops, uiParams);
     return idx >= 0 ? this.items[idx] : null;
   }
@@ -734,7 +734,7 @@ export class Ui extends BaseUi<Params> {
     return {
       autoAction: {},
       autoResize: false,
-      cursorPos: -1,
+      cursorPos: 0,
       displaySourceName: "no",
       filterFloatingPosition: "bottom",
       filterSplitDirection: "botright",


### PR DESCRIPTION
`cursorPos` of uiParams is set `-1`. But in doc, `0`.  
When `cursorPos` is -1, the following bug occurs. The cursor moves to an unexpected position. So I think 0 is correct.

https://user-images.githubusercontent.com/61523777/187329681-d5ad539a-fea9-4b68-b688-f1ca0269b441.mov

Also, I fixed the syntax error: Line 441.  The `async` method must return `Promis<T>`.