### PR TITLE
Fix example in doc

### DIFF
--- a/doc/ddu-ui-ff.txt
+++ b/doc/ddu-ui-ff.txt
@@ -433,10 +433,10 @@ must force this behaviour.
 	function! s:ddu_filter_my_settings() abort
 	  inoremap <buffer> <C-j>
 	  \ <Cmd>call ddu#ui#ff#execute(
-	  \ "call cursor(line('.')+1,0) | redraw")<CR>
+	  \ "call cursor(line('.')+1,0)<Bar>redraw")<CR>
 	  inoremap <buffer> <C-k>
 	  \ <Cmd>call ddu#ui#ff#execute(
-	  \ "call cursor(line('.')-1,0) | redraw")<CR>
+	  \ "call cursor(line('.')-1,0)<Bar>redraw")<CR>
 	endfunction
 <
 Q: I want to define |ddu-option-name| depend key mappings.


### PR DESCRIPTION
## Why

Character `|` inside `<Cmd>` should be escaped.

```
E5520: <Cmd> mapping must end with <CR>
```