### PR TITLE
Apply floating highlight also preview window

### DIFF
--- a/denops/@ddu-ui-ff/preview.ts
+++ b/denops/@ddu-ui-ff/preview.ts
@@ -116,6 +116,15 @@ export class PreviewUi {
       return flag;
     }
 
+    if (uiParams.previewFloating && uiParams.highlights.floating != null) {
+      await fn.setwinvar(
+        denops,
+        this.previewWinId,
+        "&winhighlight",
+        uiParams.highlights.floating,
+      );
+    }
+
     await this.jump(denops, previewer);
 
     const previewBufnr = await fn.bufnr(denops);


### PR DESCRIPTION
I want to apply `floating` of `ddu-ui-ff-param-highlights` to preview window. I changed to that in this PR.