### PR TITLE
Allow chooseAction to be executed even when the items are empty.

### DIFF
--- a/denops/@ddu-uis/ff.ts
+++ b/denops/@ddu-uis/ff.ts
@@ -507,9 +507,6 @@ export class Ui extends BaseUi<Params> {
       await this.closeFilterWindow(args.denops);
 
       const items = await this.getItems(args.denops);
-      if (items.length == 0) {
-        return ActionFlags.None;
-      }
 
       const actions = await args.denops.call(
         "ddu#get_item_actions",


### PR DESCRIPTION
ddu.vim can now get an action even if the item is empty in commit https://github.com/Shougo/ddu.vim/commit/e2114fd24d5a9ab1e01cc9ef9e481bb3ec19f3b4.
So `chooseAction` can now be performed even if the item is empty.