### PR TITLE
Add an option to choose the highlight of the border of floating windows

### DIFF
--- a/autoload/ddu/ui/ff/filter.vim
+++ b/autoload/ddu/ui/ff/filter.vim
@@ -123,11 +123,6 @@ function! s:init_buffer(name, params) abort
     silent execute direction 'sbuffer' bufnr
   endif
 
-  if has('nvim') && is_floating && a:params.highlights->has_key('floating')
-    call setwinvar(bufnr->bufwinnr(),
-          \ '&winhighlight', 'Normal:' .. a:params.highlights.floating)
-  endif
-
   let b:ddu_ui_name = a:name
 
   setlocal bufhidden=hide

--- a/autoload/ddu/ui/ff/filter.vim
+++ b/autoload/ddu/ui/ff/filter.vim
@@ -106,7 +106,8 @@ function! ddu#ui#ff#filter#_floating(bufnr, parent, params) abort
   endif
 
   call nvim_win_set_option(id, 'winhighlight',
-        \ 'Normal:' .. a:params.highlights->get('floating', 'NormalFloat'))
+        \ 'Normal:' .. a:params.highlights->get('floating', 'NormalFloat') ..
+        \ ',FloatBorder:' .. a:params.highlights->get('floatingBorder', 'FloatBorder'))
 endfunction
 
 function! s:init_buffer(name, params) abort

--- a/denops/@ddu-uis/ff.ts
+++ b/denops/@ddu-uis/ff.ts
@@ -24,6 +24,7 @@ type DoActionParams = {
 
 type HighlightGroup = {
   floating?: string;
+  floatingBorder?: string;
   preview?: string;
   prompt?: string;
   selected?: string;
@@ -248,16 +249,20 @@ export class Ui extends BaseUi<Params> {
           "border": args.uiParams.floatingBorder,
         });
 
+        const winnr = await fn.bufwinnr(args.denops, bufnr);
+        const highlight = args.uiParams.highlights?.floating ?? "NormalFloat";
+        const floatingHighlight = args.uiParams.highlights?.floatingBorder ?? "FloatBorder";
+
         await fn.setwinvar(
           args.denops,
-          await fn.bufwinnr(args.denops, bufnr),
+          winnr,
           "&winhighlight",
-          `Normal:${args.uiParams.highlights?.floating ?? "NormalFloat"}`,
+          `Normal:${highlight},FloatBorder:${floatingHighlight}`,
         );
 
         await fn.setwinvar(
           args.denops,
-          await fn.bufwinnr(args.denops, bufnr),
+          winnr,
           "&statusline",
           currentStatusline,
         );

--- a/doc/ddu-ui-ff.txt
+++ b/doc/ddu-ui-ff.txt
@@ -278,6 +278,10 @@ highlights	(dictionary)
 		Specify floating window background highlight.
 		Default: "NormalFloat"
 
+		floatingBorder			(string)
+		Specify border highlight of flowing window
+		Default: "FloatBorder"
+
 		preview				(string)
 		Specify preview window highlight.
 		Default: "Search"


### PR DESCRIPTION
Why not 😃 
The default value `FloatBorder` is chosen as the same as `nvim_open_win`.

The PR includes a small refactoring as well:

- Avoid multiple calls of `fn.bufwinnr`
- Removes a duplicated code to set the highlight of the filter.

Hope you like the changes.