### PR TITLE
Add sync option to AutoAction parameter

### DIFF
--- a/autoload/ddu/ui/ff.vim
+++ b/autoload/ddu/ui/ff.vim
@@ -235,7 +235,11 @@ function! s:do_auto_action() abort
 
   const text = bufnr->getbufline(s:getcurpos(winid)[1])[0]
   if text != s:cursor_text
-    call ddu#ui#ff#do_action(s:auto_action.name, s:auto_action.params)
+    if s:auto_action.sync
+      call ddu#ui#sync_action(s:auto_action.name, s:auto_action.params)
+    else
+      call ddu#ui#do_action(s:auto_action.name, s:auto_action.params)
+    endif
     let s:cursor_text = text
   endif
 endfunction

--- a/denops/@ddu-uis/ff.ts
+++ b/denops/@ddu-uis/ff.ts
@@ -34,6 +34,7 @@ type AutoAction = {
   name?: string;
   params?: unknown;
   delay?: number;
+  sync?: boolean;
 };
 
 type FloatingBorder =
@@ -287,13 +288,10 @@ export class Ui extends BaseUi<Params> {
       await batch(args.denops, async (denops: Denops) => {
         await denops.call("ddu#ui#ff#_reset_auto_action");
         if (hasAutoAction) {
-          const autoAction = args.uiParams.autoAction;
-          if (!("params" in autoAction)) {
-            autoAction.params = {};
-          }
-          if (!("delay" in autoAction)) {
-            autoAction.delay = 100;
-          }
+          const autoAction = Object.assign(
+            { delay: 100, params: {}, sync: true },
+            args.uiParams.autoAction,
+          );
           await denops.call(
             "ddu#ui#ff#_set_auto_action",
             autoAction,
@@ -1023,7 +1021,7 @@ export class Ui extends BaseUi<Params> {
       ) {
         const prevName = await fn.bufname(args.denops, args.context.bufNr);
         await args.denops.cmd(
-            prevName != args.context.bufName
+          prevName != args.context.bufName
             ? "enew"
             : `buffer ${args.context.bufNr}`,
         );
@@ -1270,7 +1268,7 @@ export class Ui extends BaseUi<Params> {
   }
 
   private async setDefaultParams(denops: Denops, uiParams: Params) {
-    const columns = (await op.columns.getGlobal(denops));
+    const columns = await op.columns.getGlobal(denops);
     if (uiParams.winWidth == 0) {
       uiParams.winWidth = Math.trunc(columns / 2);
     }

--- a/doc/ddu-ui-ff.txt
+++ b/doc/ddu-ui-ff.txt
@@ -196,6 +196,11 @@ autoAction	(dictionary)
 
 		Default: {}
 
+		sync				(boolean)	(Optional)
+		If it is true, action is executed synchronously.
+
+		Default: v:true
+
 					    	*ddu-ui-ff-param-autoResize*
 autoResize	(boolean)
 		Auto resize the window height automatically.


### PR DESCRIPTION
## Problem
The screen flickers when using auto preview. This is because preview action is executed asynchronously.

## Solution
Add `sync` option.
