### PR TITLE
Fix preview

### DIFF
--- a/denops/@ddu-ui-ff/preview.ts
+++ b/denops/@ddu-ui-ff/preview.ts
@@ -305,7 +305,7 @@ export class PreviewUi {
     previewer: BufferPreviewer | NoFilePreviewer,
   ): Promise<string[]> {
     if (previewer.kind === "buffer") {
-      const bufferPath = previewer?.expr ?? previewer?.path;
+      const bufferPath = previewer?.expr || previewer?.path;
       if (
         previewer.path && await exists(previewer.path) &&
         !(await isDirectory(previewer.path))


### PR DESCRIPTION
0 is not nullish, so bufferPath is able to be 0. But 0 is falsy, so I can't get to fn.bufexists().

Also, even if you could get there, bufexists(0) would not be the result you want. 0 indicates ddu buffer.