### PR TITLE
Fix do_auto_action

### DIFF
--- a/autoload/ddu/ui/ff.vim
+++ b/autoload/ddu/ui/ff.vim
@@ -287,14 +287,13 @@ let s:auto_action = {}
 let s:debounce_timer = -1
 function! ddu#ui#ff#_do_auto_action() abort
   silent! call timer_stop(s:debounce_timer)
+  if empty(s:auto_action)
+    return
+  endif
   let s:debounce_timer = timer_start(
         \ s:auto_action.delay, { -> s:do_auto_action() })
 endfunction
 function! s:do_auto_action() abort
-  if empty(s:auto_action)
-    return
-  endif
-
   const winid = (&l:filetype ==# 'ddu-ff'
         \        || !('g:ddu#ui#ff#_filter_parent_winid'->exists()))
         \ ? win_getid() : g:ddu#ui#ff#_filter_parent_winid


### PR DESCRIPTION
Fix the following error:

```
[denops] Failed to handle message 2,invoke,dispatch,ddu,uiAction,file_rec,cursorNext,[object Object] 0,function ddu#ui#ff#_cursor[10]..ddu#ui#ff#_do_auto_action, line 2: Vim(let):E716: Key not present in Dictionary: "delay, { -> s:do_auto_action() })"
```

This error is caused when I don't set autoAction. 
Because `s:auto_action` will set be `{}` by `ddu#ui#ff#_reset_auto_action()`, so the `delay` key will be undefined.