### PR TITLE
Add new option to change "CursorLine" highlight of floating window for Neovim

### DIFF
--- a/denops/@ddu-ui-ff/preview.ts
+++ b/denops/@ddu-ui-ff/preview.ts
@@ -133,11 +133,13 @@ export class PreviewUi {
       const highlight = uiParams.highlights?.floating ?? "NormalFloat";
       const borderHighlight = uiParams.highlights?.floatingBorder ??
         "FloatBorder";
+      const cursorLineHighlight = uiParams.highlights?.floatingCursorLine ??
+        "CursorLine";
       await fn.setwinvar(
         denops,
         this.previewWinId,
         "&winhighlight",
-        `Normal:${highlight},FloatBorder:${borderHighlight}`,
+        `Normal:${highlight},FloatBorder:${borderHighlight},CursorLine:${cursorLineHighlight}`,
       );
     }
 

--- a/denops/@ddu-uis/ff.ts
+++ b/denops/@ddu-uis/ff.ts
@@ -33,6 +33,7 @@ type HighlightGroup = {
   filterText?: string;
   floating?: string;
   floatingBorder?: string;
+  floatingCursorLine?: string;
   preview?: string;
   prompt?: string;
   selected?: string;
@@ -321,6 +322,8 @@ export class Ui extends BaseUi<Params> {
       const highlight = args.uiParams.highlights?.floating ?? "NormalFloat";
       const borderHighlight = args.uiParams.highlights?.floatingBorder ??
         "FloatBorder";
+      const cursorLineHighlight =
+        args.uiParams.highlights?.floatingCursorLine ?? "CursorLine";
 
       if (hasNvim) {
         const winOpts = {
@@ -400,7 +403,7 @@ export class Ui extends BaseUi<Params> {
           args.denops,
           this.popupId,
           "&winhighlight",
-          `Normal:${highlight},FloatBorder:${borderHighlight}`,
+          `Normal:${highlight},FloatBorder:${borderHighlight},CursorLine:${cursorLineHighlight}`,
         );
 
         await fn.setwinvar(

--- a/doc/ddu-ui-ff.txt
+++ b/doc/ddu-ui-ff.txt
@@ -343,6 +343,11 @@ highlights	(dictionary)
 		Specify border highlight of flowing window
 		Default: "FloatBorder"
 
+		floatingCursorLine		(string)
+		Specify cursor line highlight of floating window
+		Default: "CursorLine"
+		NOTE: It is neovim only.
+
 		preview				(string)
 		Specify preview window highlight.
 		Default: "Search"


### PR DESCRIPTION
I would like to change the CusorLine highlight in ddu-ui-ff to make the selected choice stand out.
I have added `highlights.floatingCursorLine` to the ddu-ui-ff options. This is a Neovim-only option.