### PR TITLE
[Feature Request] Add `previewExecute` action

### DIFF
--- a/denops/@ddu-ui-ff/preview.ts
+++ b/denops/@ddu-ui-ff/preview.ts
@@ -59,6 +59,16 @@ export class PreviewUi {
     });
   }
 
+  async execute(
+    denops: Denops,
+    command: string,
+  ) {
+    if (this.previewWinId < 0) {
+      return;
+    }
+    await fn.win_execute(denops, this.previewWinId, command);
+  }
+
   async previewContents(
     denops: Denops,
     context: Context,

--- a/denops/@ddu-uis/ff.ts
+++ b/denops/@ddu-uis/ff.ts
@@ -80,6 +80,10 @@ type OnPreviewArguments = {
   previewWinId: number;
 };
 
+type PreviewExecuteParams = {
+  command: string;
+};
+
 export type Params = {
   autoAction: AutoAction;
   autoResize: boolean;
@@ -1053,6 +1057,14 @@ export class Ui extends BaseUi<Params> {
         await this.getBufnr(args.denops),
         item,
       );
+    },
+    previewExecute: async (args: {
+      denops: Denops;
+      actionParams: unknown;
+    }) => {
+      const command = (args.actionParams as PreviewExecuteParams).command;
+      await this.previewUi.execute(args.denops, command);
+      return ActionFlags.Persist;
     },
     previewPath: async (args: {
       denops: Denops;

--- a/doc/ddu-ui-ff.txt
+++ b/doc/ddu-ui-ff.txt
@@ -151,6 +151,13 @@ preview
 
 		Preview the item in preview window.
 
+					*ddu-ui-ff-action-previewExecute*
+previewExecute
+		params:
+			{command}: 	Command to execute
+
+		Execute command in preview window.
+
 					*ddu-ui-ff-action-previewPath*
 previewPath
 


### PR DESCRIPTION
I want to add "previewExecute" action, it provides preview window operation to user.

I mainly intend to scrolling preview window.

# example

```vim
nnoremap <buffer> <nowait> d <Cmd>call ddu#ui#do_action('previewExecute', #{command: "normal! \<C-d>"})<CR>
nnoremap <buffer> <nowait> u <Cmd>call ddu#ui#do_action('previewExecute', #{command: "normal! \<C-u>"})<CR>
```
