### PR TITLE
bufadd when TerminalPreview opens new window

### DIFF
--- a/denops/@ddu-ui-ff/preview.ts
+++ b/denops/@ddu-ui-ff/preview.ts
@@ -202,10 +202,18 @@ export class PreviewUi {
     previousWinId: number,
   ): Promise<ActionFlags> {
     if (this.previewWinId < 0) {
+      // Create new buffer
+      const previewBufnr = await fn.bufadd(denops, "");
+      await batch(denops, async (denops: Denops) => {
+        await fn.setbufvar(denops, previewBufnr, "&buftype", "nofile");
+        await fn.setbufvar(denops, previewBufnr, "&swapfile", 0);
+        await fn.setbufvar(denops, previewBufnr, "&bufhidden", "hide");
+      });
       this.previewWinId = await denops.call(
         "ddu#ui#ff#_open_preview_window",
         uiParams,
         bufnr,
+        previewBufnr,
         previousWinId,
         this.previewWinId,
       ) as number;


### PR DESCRIPTION
I am not too sure about this implementation.
The name of the Buffer that launches Terminal changes on its own when Terminal is launched, so I guessed that there is no need to name it.

fix: #101
