### PR TITLE
denops async errors test

### DIFF
--- a/denops/@ddu-uis/ff.ts
+++ b/denops/@ddu-uis/ff.ts
@@ -1115,6 +1115,8 @@ export class Ui extends BaseUi<Params> {
       options: DduOptions;
       uiParams: Params;
     }) => {
+      await args.denops.call("ddu#pop", args.options.name);
+
       await this.closeBuffer({
         denops: args.denops,
         context: args.context,
@@ -1122,8 +1124,6 @@ export class Ui extends BaseUi<Params> {
         uiParams: args.uiParams,
         cancel: true,
       });
-
-      await args.denops.call("ddu#pop", args.options.name);
 
       return ActionFlags.None;
     },


### PR DESCRIPTION
Minimal vimrc

```vim
set rtp+=~/work/ddu.vim
set rtp+=~/work/ddu-ui-ff
set rtp+=~/work/denops.vim
set rtp+=~/work/ddu-source-file_rec

cd ~/src/vim

call ddu#custom#patch_global('ui', 'ff')

nnoremap a <Cmd>call ddu#start(#{sources: [#{name: 'file_rec'}]})<CR>

autocmd FileType ddu-ff call s:ddu_ff_my_settings()
function s:ddu_ff_my_settings() abort
  nnoremap <buffer> q
        \ <Cmd>call ddu#ui#do_action('quit')<CR>
endfunction
```

To reproduce:

* a
* q
* a
* q
....