### PR TITLE
Pass previewWinId to callback registered as denops callback

### DIFF
--- a/denops/@ddu-uis/ff/preview.ts
+++ b/denops/@ddu-uis/ff/preview.ts
@@ -168,6 +168,7 @@ export class PreviewUi {
           {
             context,
             item,
+            previewWinId: this.previewWinId,
           },
         );
       } else {


### PR DESCRIPTION
There's previewWinId as just for callback written by TS.
I want use it from functions registered with denops#callback#register.