### PR TITLE
fix: Make highlight override cursorline in Vim9

### DIFF
--- a/autoload/ddu/ui/ff.vim
+++ b/autoload/ddu/ui/ff.vim
@@ -100,6 +100,7 @@ function ddu#ui#ff#_highlight(
       call prop_type_add(a:prop_type, #{
             \   highlight: a:highlight,
             \   priority: a:priority,
+            \   override: v:true,
             \ })
     endif
   endif


### PR DESCRIPTION
## Problem

In Vim9, `'cursorline'`  highlight always overrides highlights added by ddu-ui-ff.
It should behive same as Neovim not to override.

## Solusion

Set the `override` flag to `prop_type_add()`.
This flag has been added in patch [`9.0.0144`](https://github.com/vim/vim/commit/f4ba8bc47eb3c6b5899ef31d083b9b8f0d4ca456).
