### PR TITLE
fix: Open filter window always in top

### DIFF
--- a/autoload/ddu/ui/ff.vim
+++ b/autoload/ddu/ui/ff.vim
@@ -205,7 +205,7 @@ function ddu#ui#ff#_open_preview_window(
       call win_gotoid(winnr)
       execute 'silent rightbelow vertical sbuffer' a:preview_bufnr
       setlocal winfixwidth
-      execute 'vert resize ' .. preview_width
+      execute 'vertical resize' preview_width
       const winid = win_getid()
     endif
   elseif a:params.previewSplit ==# 'horizontal'

--- a/denops/@ddu-uis/ff.ts
+++ b/denops/@ddu-uis/ff.ts
@@ -1092,7 +1092,7 @@ export class Ui extends BaseUi<Params> {
       options: DduOptions;
       uiParams: Params;
       actionParams: unknown;
-      getPreviewer: (
+      getPreviewer?: (
         denops: Denops,
         item: DduItem,
         actionParams: BaseActionParams,
@@ -1100,7 +1100,7 @@ export class Ui extends BaseUi<Params> {
       ) => Promise<Previewer | undefined>;
     }) => {
       const item = await this.getItem(args.denops);
-      if (!item) {
+      if (!item || !args.getPreviewer) {
         return ActionFlags.None;
       }
 
@@ -1210,7 +1210,7 @@ export class Ui extends BaseUi<Params> {
       options: DduOptions;
       uiParams: Params;
       actionParams: unknown;
-      getPreviewer: (
+      getPreviewer?: (
         denops: Denops,
         item: DduItem,
         actionParams: BaseActionParams,
@@ -1218,7 +1218,7 @@ export class Ui extends BaseUi<Params> {
       ) => Promise<Previewer | undefined>;
     }) => {
       const item = await this.getItem(args.denops);
-      if (!item) {
+      if (!item || !args.getPreviewer) {
         return ActionFlags.None;
       }
 
@@ -1599,9 +1599,9 @@ export class Ui extends BaseUi<Params> {
       await fn.setbufvar(denops, bufnr, "&swapfile", 0);
 
       if (uiParams.split === "horizontal") {
-        await fn.setbufvar(denops, bufnr, "&winfixheight", 1);
+        await fn.setwinvar(denops, winid, "&winfixheight", 1);
       } else if (uiParams.split === "vertical") {
-        await fn.setbufvar(denops, bufnr, "&winfixwidth", 1);
+        await fn.setwinvar(denops, winid, "&winfixwidth", 1);
       }
     });
   }

--- a/denops/@ddu-uis/ff.ts
+++ b/denops/@ddu-uis/ff.ts
@@ -338,12 +338,6 @@ export class Ui extends BaseUi<Params> {
           winid,
           `resize ${winHeight}`,
         );
-        await fn.setwinvar(
-          args.denops,
-          winid,
-          "&winheight",
-          winHeight,
-        );
       } else {
         const header = `silent keepalt ${direction} `;
         await args.denops.cmd(

--- a/denops/@ddu-uis/ff/preview.ts
+++ b/denops/@ddu-uis/ff/preview.ts
@@ -33,7 +33,7 @@ export class PreviewUi {
   async close(denops: Denops, context: Context, uiParams: Params) {
     await this.clearHighlight(denops);
 
-    if (this.previewWinId > 0 && (await fn.winnr(denops, "$")) !== 1) {
+    if (this.visible() && (await fn.winnr(denops, "$")) !== 1) {
       if (uiParams.previewFloating && denops.meta.host !== "nvim") {
         await denops.call("popup_close", this.previewWinId);
       } else {
@@ -68,14 +68,14 @@ export class PreviewUi {
     denops: Denops,
     command: string,
   ) {
-    if (this.previewWinId < 0) {
+    if (!this.visible()) {
       return;
     }
     await fn.win_execute(denops, this.previewWinId, command);
   }
 
   isAlreadyPreviewed(item: DduItem): boolean {
-    return this.previewWinId > 0 &&
+    return this.visible() &&
       JSON.stringify(item) === JSON.stringify(this.previewedTarget);
   }
 
@@ -452,10 +452,10 @@ export class PreviewUi {
   }
 
   async clearHighlight(denops: Denops) {
-    const winid = this.previewWinId;
-    if (winid <= 0) {
+    if (!this.visible()) {
       return;
     }
+    const winid = this.previewWinId;
 
     if (this.matchIds[winid] > 0) {
       await fn.matchdelete(denops, this.matchIds[winid], winid);
@@ -476,6 +476,10 @@ export class PreviewUi {
         },
       );
     }
+  }
+
+  visible(): boolean {
+    return this.previewWinId > 0;
   }
 }
 


### PR DESCRIPTION
SSIA

Before this PR, you have seen following window layout when doing below steps:

- Set `uiParams.split` to `horizontal`
- Set `uiParams.previewSplit` to `vertical`
- call `openFilterWindow` action after `preview` or `togglePreview` action:

```
┌───────────────┬─────────────┐
│ ddu-ff-filter │             │
├───────────────┤             │
│               │             │
│               │   preview   │
│     ddu-ff    │             │
│               │             │
│               │             │
└───────────────┴─────────────┘
```

After this PR:

```
┌─────────────────────────────┐
│        ddu-ff-filter        │
├───────────────┬─────────────┤
│               │             │
│               │             │
│     ddu-ff    │   preview   │
│               │             │
│               │             │
└───────────────┴─────────────┘
```
