### PR TITLE
fix Avoid unexpected pos use if previewFloating is enabled in Vim9

### DIFF
--- a/autoload/ddu/ui/ff.vim
+++ b/autoload/ddu/ui/ff.vim
@@ -181,6 +181,7 @@ function ddu#ui#ff#_open_preview_window(
       else
         let winopts = #{
               \   pos: 'topleft',
+              \   posinvert: v:false,
               \   line: win_row + 1,
               \   col: win_col + 1,
               \   border: [],
@@ -250,6 +251,7 @@ function ddu#ui#ff#_open_preview_window(
         endif
         let winopts = #{
               \   pos: 'topleft',
+              \   posinvert: v:false,
               \   line: win_row + 1,
               \   col: win_col + 1,
               \   border: [],


### PR DESCRIPTION
SSIA

See also the `posinvert` option in `:help popup_create-arguments`.
