### PR TITLE
fix: Use bufwinnr() instead of winbufnr()

### DIFF
--- a/denops/@ddu-uis/ff/preview.ts
+++ b/denops/@ddu-uis/ff/preview.ts
@@ -58,7 +58,7 @@ export class PreviewUi {
     await batch(denops, async (denops) => {
       for (const bufnr of this.previewedBufnrs) {
         await denops.cmd(
-          `if bufexists(${bufnr}) && winbufnr(${bufnr}) < 0 | silent bwipeout! ${bufnr} | endif`,
+          `if bufexists(${bufnr}) && bufwinnr(${bufnr}) < 0 | silent bwipeout! ${bufnr} | endif`,
         );
       }
     });


### PR DESCRIPTION
## Problem

In Vim9 if `uiParams.previewFloating` is enabled, an empty window stays behind on quit.

## Solusion

Use `bufwinnr()` instead of `winbufnr()` to check buffers to wipe out.
