### PR TITLE
winIds contains previewWinId

### DIFF
--- a/denops/@ddu-uis/ff.ts
+++ b/denops/@ddu-uis/ff.ts
@@ -797,12 +797,17 @@ export class Ui extends BaseUi<Params> {
     denops: Denops;
     uiParams: Params;
   }): Promise<number[]> {
+    const winIds = [await this.#winId(args)];
     const filterBufnr = await this.#getFilterBufnr(args.denops);
     const filterWinIds = await fn.win_findbuf(
       args.denops,
       filterBufnr,
     ) as number[];
-    return [await this.#winId(args)].concat(filterWinIds);
+    winIds.push(...filterWinIds);
+    if (this.#previewUi.visible()) {
+      winIds.push(this.#previewUi.previewWinId);
+    }
+    return winIds;
   }
 
   override actions: UiActions<Params> = {

--- a/denops/@ddu-uis/ff/preview.ts
+++ b/denops/@ddu-uis/ff/preview.ts
@@ -31,6 +31,10 @@ export class PreviewUi {
   #matchIds: Record<number, number> = {};
   #previewedBufnrs: Set<number> = new Set();
 
+  get previewWinId(): number {
+    return this.#previewWinId;
+  }
+
   async close(denops: Denops, context: Context, uiParams: Params) {
     await this.clearHighlight(denops);
 


### PR DESCRIPTION
before this PR, `ddu#ui#winids({name})` return bellow
-  dduWindow
-  filterWindow ( if possible )

after this PR, return bellow
- dduWindow
-  filterWindow ( if possible )
- previewWindow ( if visible )

NOTE:
to get previewWinId, I add getter to `PreviewUi` class.
but there are other better method to get previewWinId.