### PR TITLE
fix: focus last window after close popup in Vim

### DIFF
--- a/denops/@ddu-uis/ff.ts
+++ b/denops/@ddu-uis/ff.ts
@@ -1512,6 +1512,8 @@ export class Ui extends BaseUi<Params> {
       await args.denops.call("popup_close", this.#popupId);
       await args.denops.cmd("redraw!");
       this.#popupId = -1;
+      // Focus context window
+      await fn.win_gotoid(args.denops, args.context.winId);
     } else {
       for (
         const winid of (await fn.win_findbuf(args.denops, bufnr) as number[])


### PR DESCRIPTION
## Problem and actual behavior

In Vim and using `floating`.
After the popup closes, the next window after the filter window will be focused.

## Expected

Move focus to the window that had focus before ddu started.