### PR TITLE
fix: use byte length instead character length for the item prefix

### DIFF
--- a/autoload/ddu/ui/ff.vim
+++ b/autoload/ddu/ui/ff.vim
@@ -106,7 +106,7 @@ function ddu#ui#ff#_highlight_items(
             \ hl.hl_group, hl.name, 1,
             \ s:namespace, a:bufnr,
             \ a:params.reversed ? a:max_lines - item.row + 1 : item.row,
-            \ hl.col + strwidth(item.prefix), hl.width)
+            \ hl.col + strlen(item.prefix), hl.width)
     endfor
   endfor
 


### PR DESCRIPTION
## Problem

If we make the following settings.
The highlight column position is not valid.

- Specify multibyte characters (byte length != display width) in the source name alias.
- Enable source name display.

## Cause

Column position of the highlight is calculated by byte length.
However, `strwidth()` is used.

## Fix

Use `strlen()` instead.