### PR TITLE
fix: re-create filter buffer if not exists

### DIFF
--- a/autoload/ddu/ui/ff/filter.vim
+++ b/autoload/ddu/ui/ff/filter.vim
@@ -1,5 +1,5 @@
 function ddu#ui#ff#filter#_open(name, input, parent_id, changed_params, params) abort
-  if !'s:filter_bufnr'->exists()
+  if !s:->get('filter_bufnr', -1)->bufexists()
     " NOTE: Filter buffer must be unique
     let s:filter_bufnr = bufadd('ddu-ff-filter')
   endif


### PR DESCRIPTION
Re-creates the filter buffer if the user accidentally deletes it.