### PR TITLE
Fix "No matching autocommands" error

### DIFF
--- a/autoload/ddu/ui/ff.vim
+++ b/autoload/ddu/ui/ff.vim
@@ -442,13 +442,13 @@ function ddu#ui#ff#_open_filter_window(params, input, name, length) abort
 
   let b:ddu_ui_name = a:name
 
-  doautocmd User Ddu:ui:ff:openFilterWindow
-
   augroup ddu-ui-ff-filter
     autocmd!
     autocmd User Ddu:ui:ff:openFilterWindow :
     autocmd User Ddu:ui:ff:closeFilterWindow :
   augroup END
+
+  doautocmd User Ddu:ui:ff:openFilterWindow
 
   if a:params.filterUpdateMax <= 0 || a:params.filterUpdateMax < a:length
     autocmd ddu-ui-ff-filter CmdlineChanged *
@@ -460,11 +460,11 @@ function ddu#ui#ff#_open_filter_window(params, input, name, length) abort
 
   const new_input = input(a:params.prompt, a:input)
 
+  doautocmd User Ddu:ui:ff:closeFilterWindow
+
   augroup ddu-ui-ff-filter
     autocmd!
   augroup END
-
-  doautocmd User Ddu:ui:ff:closeFilterWindow
 
   call s:check_redraw(new_input)
 


### PR DESCRIPTION
This PR suppresses "No matching autocommands" message on opening/closing filter window like this.

```
No matching autocommands: User Ddu:ui:ff:openFilterWindow
No matching autocommands: User Ddu:ui:ff:closeFilterWindow
```

#### How to reproduce

1. `vimrc.vim`

```vim
set nocompatible

set runtimepath^=~/.cache/vim/pack/minpac/opt/denops.vim
set runtimepath^=~/.cache/vim/pack/minpac/opt/ddu.vim
set runtimepath^=~/.cache/vim/pack/minpac/opt/ddu-ui-ff

call ddu#custom#patch_global(#{ ui: 'ff' })

autocmd FileType ddu-ff nnoremap i <Cmd>call ddu#ui#do_action('openFilterWindow')<CR>
autocmd FileType ddu-ff nnoremap q <Cmd>call ddu#ui#do_action('quit')<CR>

nnoremap @ <Cmd>call ddu#start()<CR>
```

2. Open Vim with `vim -u /path/to/vimrc.vim`
3. Type `@` to start ddu.
4. Type `i<CR>` to open and close filter window.
5. Check messages by `:mes`

#### Environment

- macOS Sonoma
- Vim 9.1.429
- deno 1.43.5
- ddu.vim `8fadcc364c039997b997a7485155944251315c9c`
- ddu-ui-ff `1cb70c13bc80753184c08b3954fd2e532f0ff0a9`
