### PR TITLE
Add a workaround to ignore errors E957 by matchdelete()

### DIFF
--- a/denops/@ddu-uis/ff/preview.ts
+++ b/denops/@ddu-uis/ff/preview.ts
@@ -501,7 +501,11 @@ export class PreviewUi {
     const winid = this.#previewWinId;
 
     if (this.#matchIds[winid] > 0 && await fn.winbufnr(denops, winid) > 0) {
-      await fn.matchdelete(denops, this.#matchIds[winid], winid);
+      try {
+        await fn.matchdelete(denops, this.#matchIds[winid], winid);
+      } catch (_: unknown) {
+        // workaround: The match may already have been deleted before calling matchdelete
+      }
     }
     if (denops.meta.host === "nvim") {
       const ns = await denops.call(


### PR DESCRIPTION
# Problem
when I use ddu-source-help which use buffer preview with pattern highlight, occasionally an error occurs.
It may be due to timing and could not be accurately reproduced.

# Solution
So I add a workaround to ignore such errors.
This solution is probably not good ... 
